### PR TITLE
Add 64th note duration support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -209,6 +209,7 @@ class MidiMcpServer {
                   if (typeof note.duration === 'number') {
                     // Convert numeric durations to the appropriate string
                     switch (note.duration) {
+                      case 0.0625: note.duration = '64'; break; // 64th note
                       case 0.125: note.duration = '32'; break;
                       case 0.25: note.duration = '16'; break;
                       case 0.5: note.duration = '8'; break;


### PR DESCRIPTION
## Summary
- map numeric 0.0625 durations to '64' when converting durations

## Testing
- `npm run build` *(fails: cannot reach registry)*

------
https://chatgpt.com/codex/tasks/task_b_6858e8d85b0c8320970dfb3d3845b344